### PR TITLE
Fix dns error when installing dnsmasq

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
+- name: Ensure dnsmasq is installed
+  package:
+    name: dnsmasq
+    state: present
+
 - name: Ensure systemd-resolved isn't set up to handle DNS resolution
   service:
     name: systemd-resolved
     state: stopped
     enabled: false
   when: ansible_facts['distribution'] == "Ubuntu" and ansible_facts['distribution_version'] is version('18.04', '>=')
-
-- name: Ensure dnsmasq is installed
-  package:
-    name: dnsmasq
-    state: present
 
 - name: Ensure dnsmasq config file is installed
   template:


### PR DESCRIPTION
When stopping systemd-resolved before installing the dnsmasq pkt the install is failing with `W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/focal/InRelease  Temporary failure resolving 'archive.ubuntu.com'`.
Dns needs to be present before installing the pkt.